### PR TITLE
Improved support & documentation for inky5 feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ This selection process allows for randomized backgrounds for every "badge" displ
 NOTE: SideShow will only read TGA-type image files. You can use `imagmagick` to
 convert them easily using `convert src.jpg dst.tga`
 
-It's also recommended that the images are the size of the eInk display (640x400 for InkyFrame4)
-as SideShow will draw them at (0, 0) directly.
+It's also recommended that the images are the size of the eInk display (640x400 for
+InkyFrame4, 600x448 for InkyFrame5) as SideShow will draw them at (0, 0) directly.
 
 ### Buttons
 
@@ -173,7 +173,7 @@ The current code configuration is support for the InkyFrame 4. With a couple of
 code and configuration changes, it can work on different devices or larger screen
 sizes.
 
-_The inky5 feature was added to use the "static_large" feature for the larger_
-_screen, if using the InkyFrame 5, it's recommended to enable that feature._
+If using an InkyFrame5, build with the "inky5" feature. This will also use the
+"static_large" feature for the larger screen.
 
 See the [InkyFrame](https://github.com/secfurry/inky-frame) repository for compatibility.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     // - 1: Rotate90  (Buttons on Left)
     // - 2: Rotate180 (Buttons on Bottom, Default)
     // - 3: Rotate270 (Buttons on Right)
-    sideshow::sideshow_inky4(0x2u8)
+    sideshow::sideshow(0x2u8)
 }
 
 #[panic_handler]

--- a/src/sideshow.rs
+++ b/src/sideshow.rs
@@ -82,7 +82,11 @@ pub struct SideShow<'a, const B: usize, const W: u16, const H: u16, D: BlockDevi
     board: &'a InkyBoard<'a>,
 }
 
-pub type SideShowInky4<'a, D> = SideShow<'a, 128_000, 640u16, 400u16, D>;
+#[cfg(not(feature = "inky5"))]
+pub type SideShowInky<'a, D> = SideShow<'a, 128_000, 640u16, 400u16, D>;
+
+#[cfg(feature = "inky5")]
+pub type SideShowInky<'a, D> = SideShow<'a, 134_400, 600u16, 448u16, D>;
 
 enum Action {
     None,
@@ -95,12 +99,13 @@ enum Action {
     // Custom,
 }
 
-impl<'a, D: BlockDevice> SideShowInky4<'a, D> {
+impl<'a, D: BlockDevice> SideShowInky<'a, D> {
     #[inline(always)]
-    pub fn new(b: &'a InkyBoard<'a>, root: &'a Volume<'a, D>, r: impl Into<InkyRotation>) -> Result<SideShowInky4<'a, D>, SideError> {
-        SideShowInky4::create(b, root, InkyPins::inky_frame4(), r)
+    pub fn new(b: &'a InkyBoard<'a>, root: &'a Volume<'a, D>, r: impl Into<InkyRotation>) -> Result<SideShowInky<'a, D>, SideError> {
+        SideShowInky::create(b, root, InkyPins::inky_frame4(), r)
     }
 }
+
 impl<'a, const B: usize, const W: u16, const H: u16, D: BlockDevice> SideShow<'a, B, W, H, D> {
     #[inline(always)]
     pub fn create(b: &'a InkyBoard<'a>, root: &'a Volume<'a, D>, pins: InkyPins, r: impl Into<InkyRotation>) -> Result<SideShow<'a, B, W, H, D>, SideError> {
@@ -342,15 +347,16 @@ pub fn sideshow_error(e: SideError) -> ! {
         l.activity.on();
     }
 }
+
 #[inline(always)]
-pub fn sideshow_inky4(r: impl Into<InkyRotation>) -> ! {
+pub fn sideshow(r: impl Into<InkyRotation>) -> ! {
     let b = InkyBoard::get();
     let d = b.sd_card();
     let v = d.root().unwrap_or_else(|_| sideshow_error(SideError::InvalidRoot));
     // Signal an issue if we crash after here.
     b.leds().a.on();
     b.leds().e.on();
-    SideShowInky4::new(&b, &v, r)
+    SideShowInky::new(&b, &v, r)
         .and_then(|mut x| x.run())
         .unwrap_or_else(sideshow_error)
 }


### PR DESCRIPTION
This updates the codebase with support for the 5.7" Inky Frame, tested on my device.

It feature-flags the definition of the SideShowInky type so it doesn't have to be specified in the code, and can instead be controlled via Cargo feature flag.