### PR TITLE
Implement 5-bit binary error reporting so more error flags can be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,15 @@ If SideShow encounters an error, it will switch to an error state and will requi
 to be power-cycled to clear it.
 
 Error states are indicated by the Activity and Network LEDs flashing back-and-forth
-every second with one of the button LEDs enabled.
+every second. Which button LEDs are lit up indicate the type of error that occurred.
 
-The button LED indicates the type of error that occurred.
-
-- A: __ByteFail__: Operations on the PCF stored byte failed.
-- B: __LoadFail__: Image processing operation failed. This is usually due to a badly
+- None: __ByteFail__: Operations on the PCF stored byte failed.
+- A: __LoadFail__: Image processing operation failed. This is usually due to a badly
      formatted, corrupted file or non-TGA image.
-- C: __WakeFail__: Operations on the PCF wake alarm and interrupts failed.
-- D: __InvalidPins__: Setup for the eInk display was not correct. Usually this error
+- B: __WakeFail__: Operations on the PCF wake alarm and interrupts failed.
+- A & B: __InvalidPins__: Setup for the eInk display was not correct. Usually this error
      is due to a configuration/code error.
-- E: __InvalidRoot__: Operations on the SD Card (non-image related) failed. This is
+- C: __InvalidRoot__: Operations on the SD Card (non-image related) failed. This is
      usually due to an error with the SD Card or it's formatting. Sometimes it
      will be a fluke issue, but may require re-formatting the SD Card if the error
      occurs multiple times in a row.

--- a/src/sideshow.rs
+++ b/src/sideshow.rs
@@ -23,6 +23,7 @@ extern crate core;
 extern crate inky_frame;
 extern crate rpsp;
 
+use core::clone::Clone;
 use core::convert::Into;
 use core::iter::{IntoIterator, Iterator};
 use core::option::Option::{None, Some};
@@ -67,12 +68,13 @@ const BUTTON_D: Action = Action::Prev;
 const BUTTON_E: Action = Action::Next;
 // =================== [ Configuration End ] ===================
 
+#[derive(Clone)]
 pub enum SideError {
-    ByteFail,
-    LoadFail,
-    WakeFail,
-    InvalidPins,
-    InvalidRoot,
+    ByteFail,    // (No LEDs)
+    LoadFail,    // A        
+    WakeFail,    //   B      
+    InvalidPins, // A B      
+    InvalidRoot, //     C    
 }
 
 pub struct SideShow<'a, const B: usize, const W: u16, const H: u16, D: BlockDevice> {
@@ -326,13 +328,23 @@ pub fn sideshow_error(e: SideError) -> ! {
     let i = InkyBoard::get();
     let l = i.leds();
     l.all_off();
-    match e {
-        SideError::ByteFail => l.a.on(),
-        SideError::LoadFail => l.b.on(),
-        SideError::WakeFail => l.c.on(),
-        SideError::InvalidPins => l.d.on(),
-        SideError::InvalidRoot => l.e.on(),
+
+    if e.clone() as u8 & 1 == 1 {
+        l.a.on();
     }
+    if e.clone() as u8 & 2 == 2 {
+        l.b.on();
+    }
+    if e.clone() as u8 & 4 == 4 {
+        l.c.on();
+    }
+    if e.clone() as u8 & 8 == 8 {
+        l.d.on();
+    }
+    if e.clone() as u8 & 16 == 16 {
+        l.d.on();
+    }
+
     loop {
         i.sleep(1_500);
         l.network.on();


### PR DESCRIPTION
This changes from the 5 individual error codes to a 5-bit binary mode, meaning that you could have up to 32 error codes reported via the front LEDs.

In truth, I think it might be helpful to add error reporting which uses the display, but I understand the desire to avoid that as it will be more likely to “fail safe” in use.

I plan to add a follow-up PR which adds a bunch more error codes I used while trying to debug the program on my InkyFrame 5, but I don’t believe this is necessarily the ideal approach.

Also I couldn’t find a better way to do the bitwise checks than cloning the value. Let me know if you can think of a better option!