### PR TITLE
Expand SideError with additional error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,15 @@ If SideShow encounters an error, it will switch to an error state and will requi
 to be power-cycled to clear it.
 
 Error states are indicated by the Activity and Network LEDs flashing back-and-forth
-every second with one of the button LEDs enabled.
+every second. Which button LEDs are lit up indicate the type of error that occurred.
 
-The button LED indicates the type of error that occurred.
-
-- A: __ByteFail__: Operations on the PCF stored byte failed.
-- B: __LoadFail__: Image processing operation failed. This is usually due to a badly
+- None: __ByteFail__: Operations on the PCF stored byte failed.
+- A: __LoadFail__: Image processing operation failed. This is usually due to a badly
      formatted, corrupted file or non-TGA image.
-- C: __WakeFail__: Operations on the PCF wake alarm and interrupts failed.
-- D: __InvalidPins__: Setup for the eInk display was not correct. Usually this error
+- B: __WakeFail__: Operations on the PCF wake alarm and interrupts failed.
+- A & B: __InvalidPins__: Setup for the eInk display was not correct. Usually this error
      is due to a configuration/code error.
-- E: __InvalidRoot__: Operations on the SD Card (non-image related) failed. This is
+- C: __InvalidRoot__: Operations on the SD Card (non-image related) failed. This is
      usually due to an error with the SD Card or it's formatting. Sometimes it
      will be a fluke issue, but may require re-formatting the SD Card if the error
      occurs multiple times in a row.

--- a/src/sideshow.rs
+++ b/src/sideshow.rs
@@ -23,6 +23,7 @@ extern crate core;
 extern crate inky_frame;
 extern crate rpsp;
 
+use core::clone::Clone;
 use core::convert::Into;
 use core::iter::{IntoIterator, Iterator};
 use core::option::Option::{None, Some};
@@ -67,12 +68,13 @@ const BUTTON_D: Action = Action::Prev;
 const BUTTON_E: Action = Action::Next;
 // =================== [ Configuration End ] ===================
 
+#[derive(Clone)]
 pub enum SideError {
-    ByteFail,
-    LoadFail,
-    WakeFail,
-    InvalidPins,
-    InvalidRoot,
+    ByteFail,    // (No LEDs)
+    LoadFail,    // A        
+    WakeFail,    //   B      
+    InvalidPins, // A B      
+    InvalidRoot, //     C    
 }
 
 pub struct SideShow<'a, const B: usize, const W: u16, const H: u16, D: BlockDevice> {
@@ -326,13 +328,23 @@ pub fn sideshow_error(e: SideError) -> ! {
     let i = InkyBoard::get();
     let l = i.leds();
     l.all_off();
-    match e {
-        SideError::ByteFail => l.a.on(),
-        SideError::LoadFail => l.b.on(),
-        SideError::WakeFail => l.c.on(),
-        SideError::InvalidPins => l.d.on(),
-        SideError::InvalidRoot => l.e.on(),
+
+    if e.clone() as u8 & 1 == 1 {
+        l.a.on();
     }
+    if e.clone() as u8 & 2 == 2 {
+        l.b.on();
+    }
+    if e.clone() as u8 & 4 == 4 {
+        l.c.on();
+    }
+    if e.clone() as u8 & 8 == 8 {
+        l.d.on();
+    }
+    if e.clone() as u8 & 16 == 16 {
+        l.d.on();
+    }
+
     loop {
         i.sleep(1_500);
         l.network.on();


### PR DESCRIPTION
This follows up https://github.com/secfurry/sideshow/pull/2 with many more error codes in an effort to debug the program when I was getting it running on my Inky Frame 5.

Ultimately, I don't expect this to be merged as-is, but to be treated as a proof of concept for more granular error implementation.

Note that #2 is included in this on GitHub; check the commits tab to view just the commit unique to this PR.